### PR TITLE
Add JWT authentication middleware and profile update endpoint

### DIFF
--- a/src/dtos/user.dtos.ts
+++ b/src/dtos/user.dtos.ts
@@ -51,10 +51,23 @@ export interface UserResponseDTO {
     preferences: Array<PreferenceRow> | null | undefined;
 }
 
+export interface MemberUpdateDTO {
+    email?: string;
+    name?: string;
+    nickname?: string | null;
+    gender?: string;
+    birthdate?: Date;
+    phoneNumber?: string;
+    password?: string;
+    preferences?: unknown;
+}
+
 export const bodyToUser = (body: unknown): memberBodyToDTO => {
     if (body === null || body === undefined || typeof body !== "object")
         throw new Error("body is null or undefined or not an object");
     const b = body as any;
+
+    const phoneNumber = b.phoneNumber ?? b.phone_number;
 
     if (
         b.email === null ||
@@ -71,7 +84,7 @@ export const bodyToUser = (body: unknown): memberBodyToDTO => {
         nickname: String(b.nickname),
         gender: String(b.gender),
         birthdate,
-        phoneNumber: String(b.phone_number),
+        phoneNumber: String(phoneNumber),
         password: String(b.password),
         preferences: b.preferences,
         status: Boolean(b.status),
@@ -79,6 +92,41 @@ export const bodyToUser = (body: unknown): memberBodyToDTO => {
         createdAt: new Date(),
         updatedAt: new Date(),
         lastLogin: new Date(),
+    };
+};
+
+export const bodyToUserUpdate = (body: unknown): MemberUpdateDTO => {
+    if (body === null || body === undefined || typeof body !== "object") {
+        throw new Error("body is null or undefined or not an object");
+    }
+
+    const b = body as any;
+    const phoneNumber = b.phoneNumber ?? b.phone_number;
+    const hasAnyField = [
+        "email",
+        "name",
+        "nickname",
+        "gender",
+        "birthdate",
+        "phoneNumber",
+        "password",
+        "preferences",
+        "phone_number",
+    ].some((key) => b[key] !== undefined);
+
+    if (!hasAnyField) {
+        throw new Error("No updatable fields were provided.");
+    }
+
+    return {
+        email: b.email ? String(b.email) : undefined,
+        name: b.name ? String(b.name) : undefined,
+        nickname: b.nickname !== undefined ? String(b.nickname) : undefined,
+        gender: b.gender ? String(b.gender) : undefined,
+        birthdate: b.birthdate ? new Date(b.birthdate) : undefined,
+        phoneNumber: phoneNumber ? String(phoneNumber) : undefined,
+        password: b.password ? String(b.password) : undefined,
+        preferences: b.preferences,
     };
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import express, {NextFunction, Request, Response} from "express";
 import cors from "cors";
 import morgan from "morgan";
 import cookieParser from "cookie-parser";
-import {handleUserSignUp} from "./controller/user.controller";
+import {handleUpdateProfile, handleUserLogin, handleUserSignUp} from "./controller/user.controller";
 import {handleStoreInsert} from "./controller/store.controller";
 import {handleGetMemberReview, handleGetStoreReivew, handleInsertReview} from "./controller/review.controller";
 import {
@@ -15,6 +15,7 @@ import {
 } from "./controller/mission.controller";
 import swaggerAutogen from "swagger-autogen";
 import swaggerUiExpress from "swagger-ui-express";
+import {authenticate} from "./middleware/auth.middleware";
 
 
 dotenv.config();
@@ -99,24 +100,26 @@ app.use((req, res, next) => {
 // Routes
 // #swagger.tags = ['User']
 app.post("/api/v1/users/signup", handleUserSignUp);
+app.post("/api/v1/auth/login", handleUserLogin);
+app.put("/api/v1/users/me", authenticate, handleUpdateProfile);
 // #swagger.tags = ['Store']
-app.post("/api/v1/store/insert", handleStoreInsert);
+app.post("/api/v1/store/insert", authenticate, handleStoreInsert);
 // #swagger.tags = ['Review']
-app.post("/api/v1/users/reveiws", handleInsertReview);
+app.post("/api/v1/users/reveiws", authenticate, handleInsertReview);
 // #swagger.tags = ['Mission']
-app.post("/api/v1/missions/insert", handleInsertMission);
+app.post("/api/v1/missions/insert", authenticate, handleInsertMission);
 // #swagger.tags = ['Mission']
-app.post("/api/v1/member_mission/start", handleMissionStart);
+app.post("/api/v1/member_mission/start", authenticate, handleMissionStart);
 // #swagger.tags = ['Review']
 app.get("/api/v1/store/:storeId/review/", handleGetStoreReivew);
 // #swagger.tags = ['Review']
-app.get("/api/v1/member/:memberId/review/", handleGetMemberReview);
+app.get("/api/v1/member/:memberId/review/", authenticate, handleGetMemberReview);
 // #swagger.tags = ['Mission']
 app.get("/api/v1/store/:storeId/mission/", handleGetStoreMission);
 // #swagger.tags = ['Mission']
-app.get("/api/v1/member/:memberId/member_mission/", handleGetOnMission);
+app.get("/api/v1/member/:memberId/member_mission/", authenticate, handleGetOnMission);
 // #swagger.tags = ['Mission']
-app.patch("/api/v1/member/:memberId/mission/:missionId/setcompelete", handleSetMissionCompelete);
+app.patch("/api/v1/member/:memberId/mission/:missionId/setcompelete", authenticate, handleSetMissionCompelete);
 
 interface CustomError extends Error {
     status?: number;

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -1,0 +1,29 @@
+import {NextFunction, Request, Response} from "express";
+import {StatusCodes} from "http-status-codes";
+import {verifyToken} from "../utils/jwt";
+import {AuthenticatedRequest} from "../types/auth";
+
+export const authenticate = (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+): void => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+        res
+            .status(StatusCodes.UNAUTHORIZED)
+            .error({errorCode: "AUTH001", reason: "로그인이 필요합니다."});
+        return;
+    }
+
+    const token = authHeader.split(" ")[1];
+    try {
+        const payload = verifyToken(token);
+        (req as AuthenticatedRequest).user = {id: Number(payload.id), email: String(payload.email)};
+        next();
+    } catch (err: any) {
+        res
+            .status(StatusCodes.UNAUTHORIZED)
+            .error({errorCode: "AUTH002", reason: err?.message ?? "유효하지 않은 토큰입니다."});
+    }
+};

--- a/src/repository/mission.repository.ts
+++ b/src/repository/mission.repository.ts
@@ -103,7 +103,15 @@ export const getOnMissionRepos = async (
             },
             orderBy: {id: "asc"},
             take: 5
-        })
+        }) as Array<{
+            id: bigint;
+            memberId: bigint;
+            missionId: bigint;
+            createdAt: Date | null;
+            deadline: Date | null;
+            activated: boolean | null;
+            isCompleted: boolean | null;
+        }>;
         if (!onMissions) {
             return 0;
         }
@@ -111,7 +119,13 @@ export const getOnMissionRepos = async (
             where: {
                 id: {in: onMissions.map(mission => mission.missionId)}
             }
-        })
+        }) as Array<{
+            id: bigint;
+            title: string | null;
+            description: string | null;
+            pointReward: bigint | null;
+            storeId: bigint | null;
+        }>;
         if (!missions) {
             return 1;
         }
@@ -123,13 +137,13 @@ export const getOnMissionRepos = async (
                         .filter((storeId): storeId is bigint => storeId !== null)
                 }
             }
-        })
+        }) as Array<{ id: bigint; name: string | null }>;
         if (!stores) {
             return 2;
         }
-        const result = onMissions.map(onmission => {
-            const mission = missions.find(mission => mission.id === onmission.missionId);
-            const store = stores.find(store => store.id === mission?.storeId);
+        const result = onMissions.map((onmission) => {
+            const mission = missions.find((mission) => mission.id === onmission.missionId);
+            const store = stores.find((store) => store.id === mission?.storeId);
             return {
                 id: Number(onmission.id),
                 member_id: Number(onmission.memberId),

--- a/src/repository/review.repository.ts
+++ b/src/repository/review.repository.ts
@@ -61,14 +61,14 @@ export const getMemberReviews = async (
                 orderBy: {id: "asc"},
                 take: 5
             }
-        )
+        ) as Array<{ grade: string | null; description: string | null; createdAt: Date | null; storeId: bigint }>;
         const stores = await prisma.store.findMany({
-            where: {id: {in: reviews.map(review => review.storeId)}},
+            where: {id: {in: reviews.map((review) => review.storeId)}},
             select: {name: true, id: true}
-        })
+        }) as Array<{ name: string | null; id: bigint }>;
 
-        const result = reviews.map(review => {
-            const storeObj = stores.find(store => store.id === review.storeId);
+        const result = reviews.map((review) => {
+            const storeObj = stores.find((store) => store.id === review.storeId);
             return {
                 nickname: member.nickname ? String(member.nickname) : null,
                 store_name: storeObj ? String(storeObj.name) : "",

--- a/src/repository/store.repository.ts
+++ b/src/repository/store.repository.ts
@@ -49,14 +49,14 @@ export const getStoreReviews = async (storeId: number, cursor: number): Promise<
                 orderBy: {id: "asc"},
                 take: 5
             }
-        )
+        ) as Array<{ grade: string | null; description: string | null; createdAt: Date | null; memberId: bigint }>;
         const nicknames = await prisma.member.findMany({
-            where: {id: {in: reviews.map(review => review.memberId)}},
+            where: {id: {in: reviews.map((review) => review.memberId)}},
             select: {nickname: true, id: true}
-        })
+        }) as Array<{ nickname: string | null; id: bigint }>;
 
-        const result = reviews.map(review => {
-            const nicknameObj = nicknames.find(nick => nick.id === review.memberId);
+        const result = reviews.map((review) => {
+            const nicknameObj = nicknames.find((nick) => nick.id === review.memberId);
             return {
                 nickname: nicknameObj ? String(nicknameObj.nickname) : null,
                 store_name: String(store.name),
@@ -102,8 +102,8 @@ export const getMissionFromStore = async (
             },
             orderBy: {id: "asc"},
             take: 5
-        })
-        const result = missions.map(mission => ({
+        }) as Array<{ id: bigint; title: string | null; description: string | null; pointReward: bigint | null }>;
+        const result = missions.map((mission) => ({
             id: Number(mission.id),
             title: String(mission.title),
             description: String(mission.description),

--- a/src/repository/user.repository.ts
+++ b/src/repository/user.repository.ts
@@ -1,5 +1,4 @@
 import {prisma} from "../db.config";
-import {createHash} from "crypto"
 import {memberEntityDB} from "../dtos/user.dtos";
 
 // Payload used to insert a user into DB (subset of memberBodyToDTO)
@@ -18,6 +17,20 @@ export interface UserInsertPayload {
     lastLogin: Date;
 }
 
+export interface UserUpdatePayload {
+    email?: string;
+    name?: string;
+    nickname?: string | null;
+    gender?: string;
+    birthdate?: Date;
+    phoneNumber?: string;
+    password?: string;
+    status?: string | boolean;
+    point?: number;
+    updatedAt?: Date;
+    lastLogin?: Date;
+}
+
 // Add new user; returns inserted ID or null if email already exists
 export const addUser = async (
     data: UserInsertPayload,
@@ -32,9 +45,6 @@ export const addUser = async (
         if (user) {
             return null
         } else {
-            const hashedPassword = createHash("sha256")
-                .update(String(data.password))
-                .digest("hex");
             const addnewUser = await prisma.member.create({
                 data: {
                     email: data.email,
@@ -47,7 +57,7 @@ export const addUser = async (
                     status: String(data.status),
                     lastLogin: new Date(),
                     phoneNumber: data.phoneNumber,
-                    password: hashedPassword,
+                    password: data.password,
                     point: Number(data.point)
                 }
             });
@@ -68,24 +78,65 @@ export const getUser = async (userId: number): Promise<memberEntityDB | null> =>
         if (!user) {
             return null
         }
-        return {
-            id: Number(user.id),
-            email: String(user.email),
-            name: String(user.name),
-            nickname: user.nickname ? String(user.nickname) : null,
-            gender: String(user.gender),
-            birthdate: new Date(String(user.birthdate)),
-            phone_number: String(user.phoneNumber),
-            point: Number(user.point),
-            status: Boolean(user.status),
-            created_at: new Date(String(user.createdAt)),
-            updated_at: new Date(String(user.updatedAt)),
-            last_login: new Date(String(user.lastLogin)),
-        };
+        return mapMember(user);
     } catch (err) {
         throw new Error("The user does not exist. {" + err + "}");
     }
 
+};
+
+export const findUserByEmail = async (
+    email: string,
+): Promise<(memberEntityDB & { password: string }) | null> => {
+    const user = await prisma.member.findFirst({
+        where: {email},
+    });
+
+    if (!user) {
+        return null;
+    }
+
+    const mapped = mapMember(user);
+    return {...mapped, password: String(user.password)};
+};
+
+export const updateUserById = async (
+    userId: number,
+    updates: UserUpdatePayload,
+): Promise<number> => {
+    const updated = await prisma.member.update({
+        where: {id: BigInt(userId)},
+        data: {
+            email: updates.email,
+            name: updates.name,
+            nickname: updates.nickname,
+            gender: updates.gender,
+            birthdate: updates.birthdate,
+            updatedAt: updates.updatedAt,
+            status: updates.status?.toString(),
+            lastLogin: updates.lastLogin,
+            phoneNumber: updates.phoneNumber,
+            password: updates.password,
+            point: updates.point,
+        },
+    });
+
+    return Number(updated.id);
+};
+
+export const replaceUserPreferences = async (
+    userId: number,
+    preferences: string[],
+): Promise<void> => {
+    await prisma.foodCategory.deleteMany({where: {memberId: userId}});
+    if (preferences.length === 0) return;
+
+    await prisma.foodCategory.createMany({
+        data: preferences.map((preferFood) => ({
+            memberId: Number(userId),
+            preferFood: String(preferFood),
+        })),
+    });
 };
 
 // Map preferred food category for a user; returns created id (manual incremental)
@@ -120,7 +171,7 @@ export const getUserPreferencesByUserId = async (
         const prefs = await prisma.foodCategory.findMany({
             select: {id: true, memberId: true, preferFood: true},
             where: {memberId: userId}
-        });
+        }) as Array<{ id: bigint; memberId: bigint; preferFood: string | null }>;
         return prefs.map((row) => ({
             id: Number(row.id),
             member_id: Number(row.memberId),
@@ -131,3 +182,18 @@ export const getUserPreferencesByUserId = async (
     }
 
 };
+
+const mapMember = (user: any): memberEntityDB => ({
+    id: Number(user.id),
+    email: String(user.email),
+    name: String(user.name),
+    nickname: user.nickname ? String(user.nickname) : null,
+    gender: String(user.gender),
+    birthdate: new Date(String(user.birthdate)),
+    phone_number: String(user.phoneNumber),
+    point: Number(user.point),
+    status: Boolean(user.status),
+    created_at: new Date(String(user.createdAt)),
+    updated_at: new Date(String(user.updatedAt)),
+    last_login: new Date(String(user.lastLogin)),
+});

--- a/src/service/user.service.ts
+++ b/src/service/user.service.ts
@@ -1,18 +1,22 @@
 import crypto from "crypto";
-import type {memberBodyToDTO, memberEntityDB, UserResponseDTO,} from "../dtos/user.dtos";
+import type {MemberUpdateDTO, memberBodyToDTO, memberEntityDB, UserResponseDTO,} from "../dtos/user.dtos";
 import {responseFromUser} from "../dtos/user.dtos";
 
 import {
     addUser,
+    findUserByEmail,
     getUser,
     getUserPreferencesByUserId,
     PreferenceRow,
+    replaceUserPreferences,
     setPreference,
+    updateUserById,
 } from "../repository/user.repository";
 import {DuplicateEmailError, NoPreferenceError,} from "../error";
+import {signToken} from "../utils/jwt";
 
 // Simple password hashing (demo only). Consider bcrypt/argon2 for production.
-const hashPassword = (password: string): string => {
+export const hashPassword = (password: string): string => {
     return crypto.createHash("sha256").update(password).digest("hex");
 };
 
@@ -20,6 +24,38 @@ export const userSignUp = async (
     data: memberBodyToDTO,
 ): Promise<UserResponseDTO> => {
     const hashedPassword = hashPassword(data.password);
+
+    const existingUser = await findUserByEmail(data.email);
+    const prefs = Array.isArray((data as any).preferences)
+        ? ((data as any).preferences as string[])
+        : [];
+
+    if (existingUser) {
+        const updates = {
+            name: data.name,
+            nickname: data.nickname,
+            gender: data.gender,
+            birthdate: data.birthdate,
+            phoneNumber: data.phoneNumber,
+            password: hashedPassword,
+            status: data.status,
+            point: data.point,
+            updatedAt: new Date(),
+            lastLogin: new Date(),
+        };
+
+        await updateUserById(existingUser.id, updates);
+        if (prefs.length > 0) {
+            await replaceUserPreferences(existingUser.id, prefs);
+        }
+
+        const user = await getUser(existingUser.id);
+        const preferences = await getUserPreferencesByUserId(existingUser.id);
+        if (!user) {
+            throw new Error("가입한 유저를 찾을 수 없습니다.");
+        }
+        return await responseFromUser({user, preferences});
+    }
 
     const joinUserId: number | null = await addUser({
         email: data.email,
@@ -40,11 +76,6 @@ export const userSignUp = async (
         throw new DuplicateEmailError("이미 존재하는 이메일.", data);
     }
 
-    // preferences가 배열이라고 가정하고 순회
-    // unknown 타입을 안전하게 처리하려면 런타임 체크를 추가합니다.
-    const prefs = Array.isArray((data as any).preferences)
-        ? ((data as any).preferences as string[])
-        : [];
     if (prefs.length === 0) {
         throw new NoPreferenceError("선호도를 선택해야합니다!", data);
     }
@@ -59,6 +90,64 @@ export const userSignUp = async (
     }
     const preferences: PreferenceRow[] =
         await getUserPreferencesByUserId(joinUserId);
+
+    return await responseFromUser({user, preferences});
+};
+
+export const loginUser = async (
+    email: string,
+    password: string,
+): Promise<{ token: string; user: UserResponseDTO }> => {
+    const existingUser = await findUserByEmail(email);
+
+    if (!existingUser) {
+        throw new DuplicateEmailError("이메일 또는 비밀번호가 올바르지 않습니다.", null);
+    }
+
+    const hashedPassword = hashPassword(password);
+    if (existingUser.password !== hashedPassword) {
+        throw new DuplicateEmailError("이메일 또는 비밀번호가 올바르지 않습니다.", null);
+    }
+
+    const preferences = await getUserPreferencesByUserId(existingUser.id);
+    const user = await responseFromUser({user: existingUser, preferences});
+    const token = signToken({id: existingUser.id, email: existingUser.email});
+
+    return {token, user};
+};
+
+export const updateUserProfile = async (
+    userId: number,
+    data: MemberUpdateDTO,
+): Promise<UserResponseDTO> => {
+    const updates: any = {};
+
+    if (data.name !== undefined) updates.name = data.name;
+    if (data.nickname !== undefined) updates.nickname = data.nickname;
+    if (data.gender !== undefined) updates.gender = data.gender;
+    if (data.birthdate !== undefined) updates.birthdate = data.birthdate;
+    if (data.phoneNumber !== undefined) updates.phoneNumber = data.phoneNumber;
+    if (data.email !== undefined) updates.email = data.email;
+    if (data.password !== undefined) updates.password = hashPassword(data.password);
+
+    if (Object.keys(updates).length > 0) {
+        updates.updatedAt = new Date();
+        await updateUserById(userId, updates);
+    }
+
+    const prefs = Array.isArray((data as any).preferences)
+        ? ((data as any).preferences as string[])
+        : null;
+    if (prefs) {
+        await replaceUserPreferences(userId, prefs);
+    }
+
+    const user = await getUser(userId);
+    const preferences = await getUserPreferencesByUserId(userId);
+
+    if (!user) {
+        throw new Error("가입한 유저를 찾을 수 없습니다.");
+    }
 
     return await responseFromUser({user, preferences});
 };

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,15 @@
+import {Request} from "express";
+
+export interface AuthUser {
+    id: number;
+    email: string;
+}
+
+export interface AuthenticatedRequest<
+    P = any,
+    ResBody = any,
+    ReqBody = any,
+    ReqQuery = any,
+> extends Request<P, ResBody, ReqBody, ReqQuery> {
+    user?: AuthUser;
+}

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,0 +1,58 @@
+import crypto from "crypto";
+
+export interface AuthTokenPayload {
+    id: number;
+    email: string;
+    exp?: number;
+}
+
+const base64UrlEncode = (input: string | Buffer): string =>
+    Buffer.from(input).toString("base64url");
+
+const base64UrlDecode = (input: string): Buffer => Buffer.from(input, "base64url");
+
+const JWT_SECRET = process.env.JWT_SECRET ?? "dev-secret";
+
+export const signToken = (
+    payload: AuthTokenPayload,
+    expiresInSeconds = 60 * 60 * 24 * 7,
+): string => {
+    const header = {alg: "HS256", typ: "JWT"};
+    const exp = Math.floor(Date.now() / 1000) + expiresInSeconds;
+    const body = {...payload, exp};
+
+    const encodedHeader = base64UrlEncode(JSON.stringify(header));
+    const encodedBody = base64UrlEncode(JSON.stringify(body));
+    const data = `${encodedHeader}.${encodedBody}`;
+
+    const signature = crypto
+        .createHmac("sha256", JWT_SECRET)
+        .update(data)
+        .digest("base64url");
+
+    return `${data}.${signature}`;
+};
+
+export const verifyToken = (token: string): AuthTokenPayload => {
+    const [encodedHeader, encodedBody, signature] = token.split(".");
+    if (!encodedHeader || !encodedBody || !signature) {
+        throw new Error("Invalid token format");
+    }
+
+    const data = `${encodedHeader}.${encodedBody}`;
+    const expectedSignature = crypto
+        .createHmac("sha256", JWT_SECRET)
+        .update(data)
+        .digest("base64url");
+
+    if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) {
+        throw new Error("Invalid token signature");
+    }
+
+    const payload = JSON.parse(base64UrlDecode(encodedBody).toString()) as AuthTokenPayload;
+    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
+        throw new Error("Token expired");
+    }
+
+    return payload;
+};


### PR DESCRIPTION
## Summary
- add custom JWT utilities and middleware to validate requests with bearer tokens
- allow existing users to refresh their details via signup, add login endpoint, and provide a self-profile update route
- protect mission, review, and store creation flows with authenticated member context instead of hard-coded user data

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928790303a88330a91addf2b6c58d04)